### PR TITLE
ci,build: Update checkout action and add texinfo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       EMACS_REPO: https://github.com/kiennq/emacs.git
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Get build version
         id: vars
         run: |
@@ -78,7 +78,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Msys2
         id: msys2
@@ -165,7 +165,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Clone Emacs
         run: |

--- a/emacs-build.sh
+++ b/emacs-build.sh
@@ -88,7 +88,7 @@ function check_mingw_architecture ()
 function ensure_mingw_build_software ()
 {
     echo Install essential packages
-    local build_packages="git zip unzip base-devel ${mingw_prefix}-toolchain autoconf automake"
+    local build_packages="git zip unzip base-devel ${mingw_prefix}-toolchain autoconf automake texinfo"
     pacman --noprogressbar --noconfirm --needed -S $build_packages
     if test "$?" != 0; then
         echo Unable to install $build_packages


### PR DESCRIPTION
checkout action 4 shows a Node.js 20 deprecation message,
updated to newest version.

makeinfo is required for build. Maybe texinfo was installed with
another package in the past, now it is an extra dependency.